### PR TITLE
fix: default behaviour for traffic light roads

### DIFF
--- a/Server/agentsServer/parkAgents/model.py
+++ b/Server/agentsServer/parkAgents/model.py
@@ -37,39 +37,53 @@ class ParkModel(Model):
                         self.grid.place_agent(agent, (c, self.height - r - 1))
 
                     elif col in ["S", "s"]:
+                        spawned_road = False
                         # Spawn road tile under traffic_light.
                         if col == "S":
                             for road in [lines[r - 1][c], lines[r + 1][c]]:
                                 if road in ["v", "^"]:
-                                    direction = dataDictionary[road]
                                     agent = Road(
                                         f"r_{r*self.width+c}",
                                         self,
-                                        direction
+                                        dataDictionary[road]
                                     )
-                                    self.grid.place_agent(
-                                        agent,
-                                        (c, self.height - r - 1)
-                                    )
+                                    spawned_road = True
+                                    break
+
+                            if not spawned_road:
+                                agent = Road(
+                                    f"r_{r*self.width+c}",
+                                    self,
+                                    dataDictionary["v"]
+                                )
 
                         elif col == "s":
                             for road in [lines[r][c - 1], lines[r][c + 1]]:
                                 if road in [">", "<"]:
-                                    direction = dataDictionary[road]
                                     agent = Road(
                                         f"r_{r*self.width+c}",
                                         self,
-                                        direction
+                                        dataDictionary[road]
                                     )
-                                    self.grid.place_agent(
-                                        agent,
-                                        (c, self.height - r - 1)
-                                    )
+                                    spawned_road = True
+                                    break
+
+                            if not spawned_road:
+                                agent = Road(
+                                    f"r_{r*self.width+c}",
+                                    self,
+                                    dataDictionary["v"]
+                                )
+
+                        self.grid.place_agent(
+                            agent,
+                            (c, self.height - r - 1)
+                        )
 
                         agent = Traffic_Light(
                             f"tl_{r*self.width+c}",
                             self,
-                            direction=direction,
+                            direction=agent.direction,
                             state=False if col == "S" else True,
                             timeToChange=int(dataDictionary[col]),
                         )


### PR DESCRIPTION
Now when a traffic light doesn't find the roads it expects to surround
it in order to direct it, it just uses a default direction of its either
vertical orientation (down) or horizontal orientation (left). Also
included some refactoring to avoid repetition and unnecessary variales.
